### PR TITLE
Add SSL validation suppression option

### DIFF
--- a/src/Seq.App.EmailPlus/EmailApp.cs
+++ b/src/Seq.App.EmailPlus/EmailApp.cs
@@ -99,12 +99,6 @@ namespace Seq.App.EmailPlus
 
         [SeqAppSetting(
             IsOptional = true,
-            DisplayName = "Suppress SSL Validation",
-            HelpText = "Check this box if SSL errors should be ignored. This scenario can occur if using self-signed certificates, wildcard certificates, etc. Only use if you explicitly trust the SMTP server.")]
-        public bool? SuppressSslValidation { get; set; }
-
-        [SeqAppSetting(
-            IsOptional = true,
             InputType = SettingInputType.LongText,
             DisplayName = "Body template",
             HelpText = "The template to use when generating the email body, using Handlebars.NET syntax. Leave this blank to use " +
@@ -130,8 +124,6 @@ namespace Seq.App.EmailPlus
 
         protected override void OnAttached()
         {
-            if (EnableSsl != null && SuppressSslValidation != null && (bool)EnableSsl && (bool)SuppressSslValidation)
-                ServicePointManager.ServerCertificateValidationCallback += ValidateCertificate;
 
         }
 
@@ -205,12 +197,6 @@ namespace Seq.App.EmailPlus
             }
 
             return o;
-        }
-
-        private static bool ValidateCertificate(object sender, X509Certificate certificate, X509Chain chain,
-            SslPolicyErrors errors)
-        {
-            return true;
         }
     }
 }


### PR DESCRIPTION
Hi @nblumhardt,

This is a simple pull to add an option to suppress SSL validation errors for specific scenarios, such as self-signed certs and some wildcard certificate scenarios. I've noted in the description that it should only be used if the SMTP server is explicitly trusted, but there's definitely valid scenarios for this where SSL should be used but is prevented by the standard .NET TLS validation.

I know you have some pending PRs which are obviously linked to 2021.3 and the alerting improvements. Some additional enhancement ideas that I'm contemplating to uplift the capabilities of Email Plus ...

- Given deprecation of SmtpClient, move EmailPlus to use the recommended replacement, MailKit (it's great and supports cross  platform) ... more info at https://docs.microsoft.com/en-us/dotnet/api/system.net.mail.smtpclient?view=netframework-4.7.2#remarks, but I'd be happy to take a look soon; quite straightforward overall
- Add an optional fallback mail host if delivery to the primary host fails; this would allow mail to still be delivered if you have an alternate path when the primary host is unavailable
- Optional direct delivery using DNS? Possibly option for a tertiary fallback, but might also be viable as a primary if Host is made optional, eg. if not configured use DNS ... need to think on this but seems do-able at first thought
- Add additional envelope options - eg. priority, cc, bcc, replyTo
- Option to map mail priority to event properties such as @Level or other property, like we did with Seq.App.Opsgenie
- Option to map the to/cc/bcc addresses to an event property (eg. like the Responders property from Opsgenie app)
- Possible option to send the json event as an attachment? Could be useful for some scenarios.
- Passing event tags might not fit for an SMTP scenario, although it's possible they could be passed through to the EmailPlus debug logs (below)
- Add optional alternate plain text body template; it's 'good practice' at least to include a plain text alternative
- Validation of mail addresses - probably can't return an error back to the Seq app settings when misconfigured, but we could prevent invalid mail addresses being sent and log an event, eg. warning if we suppressed one address, error if there are no valid email addresses
- Add some debug logging that would permit for alerting if any errors etc arise

All of these would be relatively straightforward to pull in, and you can probably appreciate the benefit of these. More than happy to hear your own thoughts, of course 😊

Cheers,

Matt