### PR TITLE
MailKit conversion

### DIFF
--- a/src/Seq.App.EmailPlus/DeliveryType.cs
+++ b/src/Seq.App.EmailPlus/DeliveryType.cs
@@ -1,0 +1,12 @@
+﻿namespace Seq.App.EmailPlus
+{
+    public enum DeliveryType
+    {
+        MailHost,
+        MailFallback,
+        Dns,
+        DnsFallback,
+        HostDnsFallback,
+        None = -1
+    }
+}

--- a/src/Seq.App.EmailPlus/DirectMailGateway.cs
+++ b/src/Seq.App.EmailPlus/DirectMailGateway.cs
@@ -57,10 +57,11 @@ namespace Seq.App.EmailPlus
                     {
                         lastServer = server;
                         mailResult = await TryDeliver(server, options, message, type);
+                        var lastError = dnsResult.LastError;
                         dnsResult = new DnsMailResult()
                         {
                             LastServer = server,
-                            LastError = mailResult.Errors ?? mailResult.Errors,
+                            LastError = mailResult.Errors ?? lastError,
                             Type = type,
                             Success = mailResult.Success
                         };

--- a/src/Seq.App.EmailPlus/DirectMailGateway.cs
+++ b/src/Seq.App.EmailPlus/DirectMailGateway.cs
@@ -1,15 +1,28 @@
 ﻿using System;
-using System.Net.Mail;
+using System.Threading.Tasks;
+using MailKit.Net.Smtp;
+using MimeKit;
 
 namespace Seq.App.EmailPlus
 {
     class DirectMailGateway : IMailGateway
     {
-        public void Send(SmtpClient client, MailMessage message)
+        public async Task<MailResult> Send(SmtpClient client, SmtpOptions options, MimeMessage message)
         {
             if (client == null) throw new ArgumentNullException(nameof(client));
             if (message == null) throw new ArgumentNullException(nameof(message));
-            client.Send(message);
+            try
+            {
+                await client.ConnectAsync(options.Server, options.Port, options.UseSsl);
+                await client.SendAsync(message);
+                await client.DisconnectAsync(true);
+
+                return new MailResult {Success = true};
+            }
+            catch (Exception ex)
+            {
+                return new MailResult {Success = false, Errors = ex};
+            }
         }
     }
 }

--- a/src/Seq.App.EmailPlus/DirectMailGateway.cs
+++ b/src/Seq.App.EmailPlus/DirectMailGateway.cs
@@ -7,13 +7,16 @@ namespace Seq.App.EmailPlus
 {
     class DirectMailGateway : IMailGateway
     {
-        public async Task<MailResult> Send(SmtpClient client, SmtpOptions options, MimeMessage message)
+        public async Task<MailResult> Send(SmtpOptions options, MimeMessage message)
         {
-            if (client == null) throw new ArgumentNullException(nameof(client));
             if (message == null) throw new ArgumentNullException(nameof(message));
             try
             {
-                await client.ConnectAsync(options.Server, options.Port, options.UseSsl);
+                var client = new SmtpClient();
+                
+                await client.ConnectAsync(options.Server, options.Port, options.SocketOptions);
+                if (options.RequiresAuthentication)
+                    await client.AuthenticateAsync(options.User, options.Password);
                 await client.SendAsync(message);
                 await client.DisconnectAsync(true);
 

--- a/src/Seq.App.EmailPlus/DirectMailGateway.cs
+++ b/src/Seq.App.EmailPlus/DirectMailGateway.cs
@@ -1,5 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
+using DnsClient;
+using DnsClient.Protocol;
 using MailKit.Net.Smtp;
 using MimeKit;
 
@@ -7,25 +11,125 @@ namespace Seq.App.EmailPlus
 {
     class DirectMailGateway : IMailGateway
     {
+        readonly SmtpClient _client = new SmtpClient();
+
         public async Task<MailResult> Send(SmtpOptions options, MimeMessage message)
         {
             if (message == null) throw new ArgumentNullException(nameof(message));
+            var mailResult = new MailResult();
+            var type = DeliveryType.MailHost;
+            foreach (var server in options.ServerList)
+            {
+                mailResult = await TryDeliver(server, options, message, type);
+                if (!mailResult.Success)
+                    type = DeliveryType.MailFallback;
+                else
+                    break;
+            }
+
+            return mailResult;
+        }
+
+        public async Task<DnsMailResult> SendDns(DeliveryType deliveryType, SmtpOptions options, MimeMessage message)
+        {
+            var dnsResult = new DnsMailResult {Success = true};
+            var resultList = new List<MailResult>();
+            var lastServer = string.Empty;
+            if (message == null) throw new ArgumentNullException(nameof(message));
+            var type = deliveryType;
+
             try
             {
-                var client = new SmtpClient();
-                
-                await client.ConnectAsync(options.Server, options.Port, options.SocketOptions);
-                if (options.RequiresAuthentication)
-                    await client.AuthenticateAsync(options.User, options.Password);
-                await client.SendAsync(message);
-                await client.DisconnectAsync(true);
+                var domains = GetDomains(message);
 
-                return new MailResult {Success = true};
+                var dnsClient = new LookupClient();
+                foreach (var domain in domains)
+                {
+                    type = deliveryType;
+                    lastServer = domain;
+                    var mx = await dnsClient.QueryAsync(domain, QueryType.MX);
+                    var mxServers =
+                        (from mxServer in mx.Answers
+                            where !string.IsNullOrEmpty(((MxRecord) mxServer).Exchange)
+                            select ((MxRecord) mxServer).Exchange).Select(dummy => (string) dummy).ToList();
+                    var mailResult = new MailResult();
+                    foreach (var server in mxServers)
+                    {
+                        lastServer = server;
+                        dnsResult.LastServer = server;
+                        dnsResult.Type = type;
+                        mailResult = await TryDeliver(server, options, message, type);
+                        resultList.Add(mailResult);
+
+                        if (mailResult.Success)
+                            break;
+                        type = DeliveryType.DnsFallback;
+                    }
+
+                    if (mailResult.Success) continue;
+                    dnsResult.LastServer = lastServer;
+                    dnsResult.Success = false;
+                    break;
+                }
             }
             catch (Exception ex)
             {
-                return new MailResult {Success = false, Errors = ex};
+                dnsResult.Type = type;
+                dnsResult.LastServer = lastServer;
+                dnsResult.Success = false;
+                dnsResult.LastError = ex;
+            }
+
+            dnsResult.Results = resultList;
+            return dnsResult;
+        }
+
+
+        private static IEnumerable<string> GetDomains(MimeMessage message)
+        {
+            var domains = new List<string>();
+            foreach (var to in message.To)
+            {
+                var toDomain = to.ToString().Split('@')[1];
+                if (string.IsNullOrEmpty(toDomain)) continue;
+                foreach (var domain in domains.Where(domain =>
+                    !toDomain.Equals(domain, StringComparison.OrdinalIgnoreCase)))
+                {
+                    domains.Add(toDomain);
+                }
+            }
+
+            return domains;
+        }
+
+        private async Task<MailResult> TryDeliver(string server, SmtpOptions options, MimeMessage message,
+            DeliveryType deliveryType)
+        {
+            if (string.IsNullOrEmpty(server))
+                return new MailResult {Success = false, LastServer = server, Type = deliveryType};
+            try
+            {
+                if (!string.IsNullOrEmpty(server))
+                {
+                    await _client.ConnectAsync(server, options.Port, options.SocketOptions);
+                    if (options.RequiresAuthentication)
+                        await _client.AuthenticateAsync(options.User, options.Password);
+                }
+                else
+                {
+                    var dnsClient = new LookupClient();
+                }
+
+                await _client.SendAsync(message);
+                await _client.DisconnectAsync(true);
+
+                return new MailResult {Success = true, LastServer = server, Type = deliveryType};
+            }
+            catch (Exception ex)
+            {
+                return new MailResult {Success = false, Errors = ex, LastServer = server, Type = deliveryType};
             }
         }
+
     }
 }

--- a/src/Seq.App.EmailPlus/DirectMailGateway.cs
+++ b/src/Seq.App.EmailPlus/DirectMailGateway.cs
@@ -109,19 +109,14 @@ namespace Seq.App.EmailPlus
                 return new MailResult {Success = false, LastServer = server, Type = deliveryType};
             try
             {
-                if (!string.IsNullOrEmpty(server))
-                {
-                    await _client.ConnectAsync(server, options.Port, options.SocketOptions);
-                    if (options.RequiresAuthentication)
-                        await _client.AuthenticateAsync(options.User, options.Password);
-                }
-                else
-                {
-                    var dnsClient = new LookupClient();
-                }
+                await _client.ConnectAsync(server, options.Port, options.SocketOptions);
+                if (options.RequiresAuthentication)
+                    await _client.AuthenticateAsync(options.User, options.Password);
+
 
                 await _client.SendAsync(message);
                 await _client.DisconnectAsync(true);
+
 
                 return new MailResult {Success = true, LastServer = server, Type = deliveryType};
             }

--- a/src/Seq.App.EmailPlus/DnsMailResult.cs
+++ b/src/Seq.App.EmailPlus/DnsMailResult.cs
@@ -9,6 +9,7 @@ namespace Seq.App.EmailPlus
         public DeliveryType Type { get; set; }
         public string LastServer { get; set; }
         public Exception LastError { get; set; }
-        public List<MailResult> Results { get; set; }
+        public List<Exception> Errors { get; set; } = new List<Exception>();
+        public List<MailResult> Results { get; set; } = new List<MailResult>();
     }
 }

--- a/src/Seq.App.EmailPlus/DnsMailResult.cs
+++ b/src/Seq.App.EmailPlus/DnsMailResult.cs
@@ -1,12 +1,14 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Seq.App.EmailPlus
 {
-    public class MailResult
+    public class DnsMailResult
     {
         public bool Success { get; set; }
         public DeliveryType Type { get; set; }
         public string LastServer { get; set; }
-        public Exception Errors { get; set; }
+        public Exception LastError { get; set; }
+        public List<MailResult> Results { get; set; }
     }
 }

--- a/src/Seq.App.EmailPlus/EmailApp.cs
+++ b/src/Seq.App.EmailPlus/EmailApp.cs
@@ -99,12 +99,6 @@ namespace Seq.App.EmailPlus
 
         [SeqAppSetting(
             IsOptional = true,
-            DisplayName = "Suppress SSL Validation",
-            HelpText = "Check this box if SSL errors should be ignored. This scenario can occur if using self-signed certificates, wildcard certificates, etc. Only use if you explicitly trust the SMTP server.")]
-        public bool? SuppressSslValidation { get; set; }
-
-        [SeqAppSetting(
-            IsOptional = true,
             InputType = SettingInputType.LongText,
             DisplayName = "Body template",
             HelpText = "The template to use when generating the email body, using Handlebars.NET syntax. Leave this blank to use " +
@@ -130,8 +124,6 @@ namespace Seq.App.EmailPlus
 
         protected override void OnAttached()
         {
-            if (EnableSsl != null && SuppressSslValidation != null && (bool)EnableSsl && (bool)SuppressSslValidation)
-                ServicePointManager.ServerCertificateValidationCallback += ValidateCertificate;
 
         }
 
@@ -205,12 +197,6 @@ namespace Seq.App.EmailPlus
             }
 
             return o;
-        }
-
-        private static bool ValidateCertificate(object sender, X509Certificate certificate, X509Chain chain,
-            SslPolicyErrors errors)
-        {
-            return true;
         }
     }
 }

--- a/src/Seq.App.EmailPlus/EmailApp.cs
+++ b/src/Seq.App.EmailPlus/EmailApp.cs
@@ -3,10 +3,8 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
-using System.Net;
 using System.Threading.Tasks;
 using HandlebarsDotNet;
-using MailKit.Net.Smtp;
 using MailKit.Security;
 using MimeKit;
 using Seq.Apps;
@@ -25,7 +23,7 @@ namespace Seq.App.EmailPlus
         readonly IMailGateway _mailGateway = new DirectMailGateway();
         readonly ConcurrentDictionary<uint, DateTime> _lastSeen = new ConcurrentDictionary<uint, DateTime>();
         readonly Lazy<Template> _bodyTemplate, _subjectTemplate, _toAddressesTemplate;
-        readonly SmtpOptions _options;
+        public readonly Lazy<SmtpOptions> Options;
 
         const string DefaultSubjectTemplate = @"[{{$Level}}] {{{$Message}}} (via Seq)";
         const int MaxSubjectLength = 130;
@@ -43,16 +41,18 @@ namespace Seq.App.EmailPlus
 
         public EmailApp()
         {
-            _options = _options = new SmtpOptions()
+            Options = new Lazy<SmtpOptions>(() => new SmtpOptions
             {
-                Server = Host, Port = Port ?? 25,
+                Server = Host,
+                DnsDelivery = DeliverUsingDns != null && (bool) DeliverUsingDns,
+                Port = Port ?? 25,
                 SocketOptions = EnableSsl != null && (bool) EnableSsl
                     ? SecureSocketOptions.SslOnConnect
                     : SecureSocketOptions.StartTlsWhenAvailable,
                 User = Username, Password = Password,
                 RequiresAuthentication = !string.IsNullOrEmpty(Username) && !string.IsNullOrEmpty(Password)
-            };
-            
+            });
+
             _subjectTemplate = new Lazy<Template>(() =>
             {
                 var subjectTemplate = SubjectTemplate;
@@ -95,8 +95,13 @@ namespace Seq.App.EmailPlus
         public string SubjectTemplate { get; set; }
 
         [SeqAppSetting(
-            HelpText = "The name of the SMTP server machine.")]
+            HelpText = "The name of the SMTP server machine. Optionally specify fallback hosts as comma-delimited string.",
+            IsOptional = true)]
         public new string Host { get; set; }
+
+        [SeqAppSetting(
+            HelpText = "Deliver directly using DNS. If Host is configured, this will be used as a fallback delivery mechanism.")]
+        public bool? DeliverUsingDns { get; set; }
 
         [SeqAppSetting(
             IsOptional = true,
@@ -148,20 +153,68 @@ namespace Seq.App.EmailPlus
                 _lastSeen[evt.EventType] = DateTime.UtcNow;
             }
 
-            var to = FormatTemplate(_toAddressesTemplate.Value, evt, base.Host);
+            var to = FormatTemplate(_toAddressesTemplate.Value, evt, base.Host)
+                .Split(new[] {','}, StringSplitOptions.RemoveEmptyEntries)
+                .Select(t => t.Trim()).ToList();
             var body = FormatTemplate(_bodyTemplate.Value, evt, base.Host);
             var subject = FormatTemplate(_subjectTemplate.Value, evt, base.Host).Trim().Replace("\r", "")
                 .Replace("\n", "");
             if (subject.Length > MaxSubjectLength)
                 subject = subject.Substring(0, MaxSubjectLength);
 
-            var result = await _mailGateway.Send(_options, new MimeMessage(new List<InternetAddress> {MailboxAddress.Parse(From)},
-                new List<InternetAddress> {MailboxAddress.Parse(to)}, subject,
-                (new BodyBuilder() {HtmlBody = body}).ToMessageBody()));
+            var toList = to.Select(MailboxAddress.Parse).ToList();
 
-            if (!result.Success)
-                throw result.Errors;
+            var sent = false;
+            var type = DeliveryType.None;
+            var message = new MimeMessage(
+                new List<InternetAddress> {InternetAddress.Parse(From)},
+                toList, subject, (new BodyBuilder {HtmlBody = body}).ToMessageBody());
 
+            Exception lastError = null;
+            if (Options.Value.Server.Any())
+            {
+                type = DeliveryType.MailHost;
+                var result = await _mailGateway.Send(Options.Value, message);
+
+                sent = result.Success;
+                if (!result.Success)
+                {
+                    lastError = result.Errors;
+                    Log.ForContext("From", From).ForContext("To", to).ForContext("Subject", subject)
+                        .ForContext("Success", sent).ForContext("Body", body)
+                        .ForContext(nameof(result.LastServer), result.LastServer)
+                        .ForContext(nameof(result.Type), result.Type).Error(result.Errors, "Error sending mail: ",
+                            result.Errors.Message);
+                }
+            }
+
+            if (!sent && Options.Value.DnsDelivery)
+            {
+                type = type == DeliveryType.None ? DeliveryType.Dns : DeliveryType.HostDnsFallback;
+                var result = await _mailGateway.SendDns(type, Options.Value, message);
+                sent = result.Success;
+
+                if (!result.Success)
+                {
+                    lastError = result.LastError;
+                    Log.ForContext("From", From).ForContext("To", to).ForContext("Subject", subject)
+                        .ForContext("Success", sent).ForContext("Body", body)
+                        .ForContext(nameof(result.Results), result.Results, true)
+                        .ForContext(nameof(result.LastServer), result.LastServer).Error(result.LastError,
+                            "Error sending mail via DNS: ", result.LastError.Message);
+                }
+            }
+
+            switch (sent)
+            {
+                case false when lastError != null:
+                    throw lastError;
+                case true:
+                    Log.ForContext("From", From).ForContext("To", to).ForContext("Subject", subject)
+                        .ForContext("Success", true).ForContext("Body", body)
+                        .Information("Mail Sent, From {From}, To: {To}, Subject: {Subject}");
+                    break;
+            }
         }
 
         public static string FormatTemplate(Template template, Event<LogEventData> evt, Host host)

--- a/src/Seq.App.EmailPlus/EmailApp.cs
+++ b/src/Seq.App.EmailPlus/EmailApp.cs
@@ -4,10 +4,10 @@ using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
 using System.Net;
-using System.Net.Mail;
-using System.Net.Security;
-using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
 using HandlebarsDotNet;
+using MailKit.Net.Smtp;
+using MimeKit;
 using Seq.Apps;
 using Seq.Apps.LogEvents;
 
@@ -19,11 +19,13 @@ namespace Seq.App.EmailPlus
 
     [SeqApp("Email+",
         Description = "Uses a Handlebars template to send events as SMTP email.")]
-    public class EmailApp : SeqApp, ISubscribeTo<LogEventData>
+    public class EmailApp : SeqApp, ISubscribeToAsync<LogEventData>
     {
         readonly IMailGateway _mailGateway = new DirectMailGateway();
         readonly ConcurrentDictionary<uint, DateTime> _lastSeen = new ConcurrentDictionary<uint, DateTime>();
         readonly Lazy<Template> _bodyTemplate, _subjectTemplate, _toAddressesTemplate;
+        private SmtpClient _client = new SmtpClient();
+        private SmtpOptions _options = new SmtpOptions();
 
         const string DefaultSubjectTemplate = @"[{{$Level}}] {{{$Message}}} (via Seq)";
         const int MaxSubjectLength = 130;
@@ -124,13 +126,17 @@ namespace Seq.App.EmailPlus
 
         protected override void OnAttached()
         {
-
+            _options = new SmtpOptions() {Server = Host, Port = Port ?? 25, UseSsl = EnableSsl ?? false, User = Username, Password = Password, RequiresAuthentication = !string.IsNullOrEmpty(Username) && !string.IsNullOrEmpty(Password)};
         }
 
-        public void On(Event<LogEventData> evt)
+        public async Task OnAsync(Event<LogEventData> evt)
         {
             var added = false;
-            var lastSeen = _lastSeen.GetOrAdd(evt.EventType, k => { added = true; return DateTime.UtcNow; });
+            var lastSeen = _lastSeen.GetOrAdd(evt.EventType, k =>
+            {
+                added = true;
+                return DateTime.UtcNow;
+            });
             if (!added)
             {
                 if (lastSeen > DateTime.UtcNow.AddMinutes(-SuppressionMinutes)) return;
@@ -139,18 +145,15 @@ namespace Seq.App.EmailPlus
 
             var to = FormatTemplate(_toAddressesTemplate.Value, evt, base.Host);
             var body = FormatTemplate(_bodyTemplate.Value, evt, base.Host);
-            var subject = FormatTemplate(_subjectTemplate.Value, evt, base.Host).Trim().Replace("\r", "").Replace("\n", "");
+            var subject = FormatTemplate(_subjectTemplate.Value, evt, base.Host).Trim().Replace("\r", "")
+                .Replace("\n", "");
             if (subject.Length > MaxSubjectLength)
                 subject = subject.Substring(0, MaxSubjectLength);
 
-            var client = new SmtpClient(Host, Port ?? 25) {EnableSsl = EnableSsl ?? false};
-            if (!string.IsNullOrWhiteSpace(Username))
-                client.Credentials = new NetworkCredential(Username, Password);
+            var result = await _mailGateway.Send(_client, _options, new MimeMessage(new List<InternetAddress> {MailboxAddress.Parse(From)},
+                new List<InternetAddress> {MailboxAddress.Parse(to)}, subject,
+                (new BodyBuilder() {HtmlBody = body}).ToMessageBody()));
 
-            using (var message = new MailMessage(From, to, subject, body) {IsBodyHtml = true})
-            {
-                _mailGateway.Send(client, message);
-            }
         }
 
         public static string FormatTemplate(Template template, Event<LogEventData> evt, Host host)
@@ -169,7 +172,9 @@ namespace Seq.App.EmailPlus
                 { "$Properties",          properties },
                 { "$EventType",           "$" + evt.EventType.ToString("X8") },
                 { "$Instance",            host.InstanceName },
-                { "$ServerUri",           host.BaseUri }
+                { "$ServerUri",           host.BaseUri },
+                // Note, this will only be valid when events are streamed directly to the app, and not when the app is sending an alert notification.
+                { "$EventUri",            string.Concat(host.BaseUri, "#/events?filter=@Id%20%3D%20'", evt.Id, "'&amp;show=expanded") } 
             });
 
             foreach (var property in properties)

--- a/src/Seq.App.EmailPlus/EmailPriority.cs
+++ b/src/Seq.App.EmailPlus/EmailPriority.cs
@@ -1,0 +1,12 @@
+﻿using MimeKit;
+
+namespace Seq.App.EmailPlus
+{
+    public enum EmailPriority
+    {
+        Low = MessagePriority.NonUrgent,
+        Normal = MessagePriority.Normal,
+        High = MessagePriority.Urgent,
+        UseMapping = -1,
+    }
+}

--- a/src/Seq.App.EmailPlus/HandlebarsHelpers.cs
+++ b/src/Seq.App.EmailPlus/HandlebarsHelpers.cs
@@ -2,7 +2,6 @@
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 
 namespace Seq.App.EmailPlus

--- a/src/Seq.App.EmailPlus/IMailGateway.cs
+++ b/src/Seq.App.EmailPlus/IMailGateway.cs
@@ -1,5 +1,6 @@
 ﻿
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using MimeKit;
 

--- a/src/Seq.App.EmailPlus/IMailGateway.cs
+++ b/src/Seq.App.EmailPlus/IMailGateway.cs
@@ -1,9 +1,13 @@
-﻿using System.Net.Mail;
+﻿
+
+using System.Threading.Tasks;
+using MailKit.Net.Smtp;
+using MimeKit;
 
 namespace Seq.App.EmailPlus
 {
     interface IMailGateway
     {
-        void Send(SmtpClient client, MailMessage message);
+        Task<MailResult> Send(SmtpClient client, SmtpOptions options, MimeMessage message);
     }
 }

--- a/src/Seq.App.EmailPlus/IMailGateway.cs
+++ b/src/Seq.App.EmailPlus/IMailGateway.cs
@@ -8,6 +8,6 @@ namespace Seq.App.EmailPlus
 {
     interface IMailGateway
     {
-        Task<MailResult> Send(SmtpClient client, SmtpOptions options, MimeMessage message);
+        Task<MailResult> Send(SmtpOptions options, MimeMessage message);
     }
 }

--- a/src/Seq.App.EmailPlus/IMailGateway.cs
+++ b/src/Seq.App.EmailPlus/IMailGateway.cs
@@ -1,7 +1,6 @@
 ﻿
 
 using System.Threading.Tasks;
-using MailKit.Net.Smtp;
 using MimeKit;
 
 namespace Seq.App.EmailPlus
@@ -9,5 +8,6 @@ namespace Seq.App.EmailPlus
     interface IMailGateway
     {
         Task<MailResult> Send(SmtpOptions options, MimeMessage message);
+        Task<DnsMailResult> SendDns(DeliveryType deliveryType, SmtpOptions options, MimeMessage message);
     }
 }

--- a/src/Seq.App.EmailPlus/MailResult.cs
+++ b/src/Seq.App.EmailPlus/MailResult.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Seq.App.EmailPlus
+{
+    public class MailResult
+    {
+        public bool Success;
+        public Exception Errors;
+    }
+}

--- a/src/Seq.App.EmailPlus/MailResult.cs
+++ b/src/Seq.App.EmailPlus/MailResult.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Seq.App.EmailPlus
 {
@@ -7,6 +8,7 @@ namespace Seq.App.EmailPlus
         public bool Success { get; set; }
         public DeliveryType Type { get; set; }
         public string LastServer { get; set; }
-        public Exception Errors { get; set; }
+        public Exception LastError { get; set; }
+        public List<Exception> Errors { get; set; } = new List<Exception>();
     }
 }

--- a/src/Seq.App.EmailPlus/Seq.App.EmailPlus.csproj
+++ b/src/Seq.App.EmailPlus/Seq.App.EmailPlus.csproj
@@ -17,6 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MailKit" Version="2.14.0" />
     <PackageReference Include="Seq.Apps" Version="5.1.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Handlebars.Net" Version="2.0.9" />

--- a/src/Seq.App.EmailPlus/Seq.App.EmailPlus.csproj
+++ b/src/Seq.App.EmailPlus/Seq.App.EmailPlus.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Seq.Apps" Version="5.1.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Handlebars.Net" Version="2.0.8" />
+    <PackageReference Include="Handlebars.Net" Version="2.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/src/Seq.App.EmailPlus/Seq.App.EmailPlus.csproj
+++ b/src/Seq.App.EmailPlus/Seq.App.EmailPlus.csproj
@@ -17,6 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="DnsClient" Version="1.5.0" />
     <PackageReference Include="MailKit" Version="2.14.0" />
     <PackageReference Include="Seq.Apps" Version="5.1.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />

--- a/src/Seq.App.EmailPlus/SmtpOptions.cs
+++ b/src/Seq.App.EmailPlus/SmtpOptions.cs
@@ -1,17 +1,31 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Linq;
 using MailKit.Security;
 
 namespace Seq.App.EmailPlus
 {
-    class SmtpOptions
+    public class SmtpOptions
     {
-        public string Server { get; set; } = string.Empty;
+        public string Server { get; set; }
+        public bool DnsDelivery { get; set; }
         public int Port { get; set; } = 25;
         public string User { get; set; } = string.Empty;
         public string Password { get; set; } = string.Empty;
         public bool RequiresAuthentication { get; set; }
         public SecureSocketOptions SocketOptions { get; set; }
+
+        public IEnumerable<string> ServerList
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(Server))
+                    return Server.Split(new[] {','}, StringSplitOptions.RemoveEmptyEntries)
+                        .Select(t => t.Trim()).ToList();
+                return new List<string>();
+            }
+        }
     }
+
+    
 }

--- a/src/Seq.App.EmailPlus/SmtpOptions.cs
+++ b/src/Seq.App.EmailPlus/SmtpOptions.cs
@@ -11,9 +11,7 @@ namespace Seq.App.EmailPlus
         public int Port { get; set; } = 25;
         public string User { get; set; } = string.Empty;
         public string Password { get; set; } = string.Empty;
-        public bool UseSsl { get; set; } = false;
-        public bool RequiresAuthentication { get; set; } = false;
-        public string PreferredEncoding { get; set; } = string.Empty;
-        public SecureSocketOptions? SocketOptions { get; set; }
+        public bool RequiresAuthentication { get; set; }
+        public SecureSocketOptions SocketOptions { get; set; }
     }
 }

--- a/src/Seq.App.EmailPlus/SmtpOptions.cs
+++ b/src/Seq.App.EmailPlus/SmtpOptions.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using HandlebarsDotNet.MemberAccessors;
 using MailKit.Security;
+using MimeKit;
 
 namespace Seq.App.EmailPlus
 {
@@ -13,6 +15,12 @@ namespace Seq.App.EmailPlus
         public string User { get; set; } = string.Empty;
         public string Password { get; set; } = string.Empty;
         public bool RequiresAuthentication { get; set; }
+
+        public EmailPriority Priority { get; set; } = EmailPriority.Normal;
+        public Dictionary<string, EmailPriority> PriorityMapping { get; set; } =
+            new Dictionary<string, EmailPriority>(StringComparer.OrdinalIgnoreCase);
+        public EmailPriority DefaultPriority { get; set; } = EmailPriority.Normal;
+
         public SecureSocketOptions SocketOptions { get; set; }
 
         public IEnumerable<string> ServerList
@@ -25,7 +33,31 @@ namespace Seq.App.EmailPlus
                 return new List<string>();
             }
         }
-    }
 
-    
+        public static EmailPriority ParsePriority(string priority, out Dictionary<string,EmailPriority> priorityList)
+        {
+            priorityList = new Dictionary<string, EmailPriority>(StringComparer.OrdinalIgnoreCase);
+            if (string.IsNullOrEmpty(priority)) return EmailPriority.Normal;
+            if (!priority.Contains('='))
+                return Enum.TryParse(priority, out EmailPriority priorityValue) ? priorityValue : EmailPriority.Normal;
+            foreach (var kv in priority.Split(new[] {','}, StringSplitOptions.RemoveEmptyEntries)
+                .Select(t => t.Trim()).ToList().Select(p => p.Split(new[] {'='}, StringSplitOptions.RemoveEmptyEntries).Select(t => t.Trim())
+                    .ToArray()))
+            {
+                if (kv.Length != 2 || !Enum.TryParse(kv[1], true, out EmailPriority value) ||
+                    value == EmailPriority.UseMapping) return EmailPriority.Normal;
+
+                priorityList.Add(kv[0], value);
+            }
+
+            return priorityList.Count > 0 ? EmailPriority.UseMapping : EmailPriority.Normal;
+
+        }
+
+        public static EmailPriority ParsePriority(string priority)
+        {
+            if (string.IsNullOrEmpty(priority)) return EmailPriority.Normal;
+            return Enum.TryParse(priority, out EmailPriority priorityValue) ? priorityValue : EmailPriority.Normal;
+        }
+    }
 }

--- a/src/Seq.App.EmailPlus/SmtpOptions.cs
+++ b/src/Seq.App.EmailPlus/SmtpOptions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using MailKit.Security;
+
+namespace Seq.App.EmailPlus
+{
+    class SmtpOptions
+    {
+        public string Server { get; set; } = string.Empty;
+        public int Port { get; set; } = 25;
+        public string User { get; set; } = string.Empty;
+        public string Password { get; set; } = string.Empty;
+        public bool UseSsl { get; set; } = false;
+        public bool RequiresAuthentication { get; set; } = false;
+        public string PreferredEncoding { get; set; } = string.Empty;
+        public SecureSocketOptions? SocketOptions { get; set; }
+    }
+}

--- a/test/Seq.App.EmailPlus.Tests/EmailReactorTests.cs
+++ b/test/Seq.App.EmailPlus.Tests/EmailReactorTests.cs
@@ -2,19 +2,28 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using MimeKit;
 using Seq.App.EmailPlus.Tests.Support;
 using Seq.Apps;
 using Seq.Apps.LogEvents;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Seq.App.EmailPlus.Tests
 {
     public class EmailReactorTests
     {
+        private readonly ITestOutputHelper _testOutputHelper;
+
         static EmailReactorTests()
         {
             // Ensure the handlebars helpers are registered.
             GC.KeepAlive(new EmailApp());
+        }
+
+        public EmailReactorTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
         }
 
         [Fact]
@@ -142,5 +151,56 @@ namespace Seq.App.EmailPlus.Tests
             reactor.Attach(new TestAppHost());
             Assert.True(reactor.Options.Value.ServerList.Count() == 2);
         }
+
+        [Fact]
+        public void ParseDomainTest()
+        {
+            var mail = new DirectMailGateway();
+            var domains = DirectMailGateway.GetDomains(new MimeMessage(
+                new List<InternetAddress> {InternetAddress.Parse("test@example.com")},
+                new List<InternetAddress> {InternetAddress.Parse("test2@example.com"), InternetAddress.Parse("test3@example.com"), InternetAddress.Parse("test@example2.com")}, "Test",
+                (new BodyBuilder {HtmlBody = "test"}).ToMessageBody()));
+            Assert.True(domains.Count() == 2);
+        }
+
+        //[Fact]
+        //public async Task MailHostDeliveryTest()
+        //{
+        //    var reactor = new EmailApp()
+        //    {
+        //        Host = "fqdn",
+        //        EnableSsl = false,
+        //        From = "test@example.com",
+        //        To = "testdest@example.com",
+        //        BodyTemplate = "Test Body",
+        //        SubjectTemplate = "Test Email"
+        //    };
+
+        //    reactor.Attach(new TestAppHost());
+        //    var data = Some.LogEvent(new Dictionary<string, object> { { "Name", "test" } });
+        //    await reactor.OnAsync(data);
+
+        //}
+        
+        //[Fact]
+        //public async Task SmtpDnsDeliveryTest()
+        //{
+        //    var mail = new DirectMailGateway();
+        //    var reactor = new EmailApp(mail)
+        //    {
+        //        DeliverUsingDns = true,
+        //        EnableSsl = false,
+        //        From = "test@example.com",
+        //        To = "testdest@example.com",
+        //        BodyTemplate = "Test Body",
+        //        SubjectTemplate = "Test Email"
+        //    };
+
+        //    reactor.Attach(new TestAppHost());
+        //    var x = await mail.SendDns(DeliveryType.Dns, reactor.Options.Value, new MimeMessage(
+        //        new List<InternetAddress> {InternetAddress.Parse(reactor.From)},
+        //        new List<InternetAddress> {InternetAddress.Parse(reactor.To)}, reactor.SubjectTemplate, (new BodyBuilder {HtmlBody = reactor.BodyTemplate}).ToMessageBody()));
+        //    _testOutputHelper.WriteLine("{0}: {1}", x.Success, x.LastError);
+        //}
     }
 }

--- a/test/Seq.App.EmailPlus.Tests/EmailReactorTests.cs
+++ b/test/Seq.App.EmailPlus.Tests/EmailReactorTests.cs
@@ -122,12 +122,25 @@ namespace Seq.App.EmailPlus.Tests
             };
 
             reactor.Attach(new TestAppHost());
-
             var data = Some.LogEvent(new Dictionary<string, object> { { "Name", "test" } });
             await reactor.OnAsync(data);
-
             var sent = mail.Sent.Single();
             Assert.Equal("test@example.com", sent.Message.To.ToString());
+        }
+
+        [Fact]
+        public async Task SmtpOptionsCalculated()
+        {
+            var mail = new CollectingMailGateway();
+            var reactor = new EmailApp(mail)
+            {
+                From = "from@example.com",
+                To = "{{Name}}@example.com",
+                Host = "example.com,example2.com"
+            };
+
+            reactor.Attach(new TestAppHost());
+            Assert.True(reactor.Options.Value.ServerList.Count() == 2);
         }
     }
 }

--- a/test/Seq.App.EmailPlus.Tests/EmailReactorTests.cs
+++ b/test/Seq.App.EmailPlus.Tests/EmailReactorTests.cs
@@ -110,7 +110,7 @@ namespace Seq.App.EmailPlus.Tests
 
 
         [Fact]
-        public void ToAddressesAreTemplated()
+        public async void ToAddressesAreTemplated()
         {
             var mail = new CollectingMailGateway();
             var reactor = new EmailApp(mail)
@@ -123,7 +123,7 @@ namespace Seq.App.EmailPlus.Tests
             reactor.Attach(new TestAppHost());
 
             var data = Some.LogEvent(new Dictionary<string, object> { { "Name", "test" } });
-            reactor.On(data);
+            await reactor.OnAsync(data);
 
             var sent = mail.Sent.Single();
             Assert.Equal("test@example.com", sent.Message.To.ToString());

--- a/test/Seq.App.EmailPlus.Tests/EmailReactorTests.cs
+++ b/test/Seq.App.EmailPlus.Tests/EmailReactorTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Seq.App.EmailPlus.Tests.Support;
 using Seq.Apps;
 using Seq.Apps.LogEvents;
@@ -110,7 +111,7 @@ namespace Seq.App.EmailPlus.Tests
 
 
         [Fact]
-        public async void ToAddressesAreTemplated()
+        public async Task ToAddressesAreTemplated()
         {
             var mail = new CollectingMailGateway();
             var reactor = new EmailApp(mail)

--- a/test/Seq.App.EmailPlus.Tests/EmailReactorTests.cs
+++ b/test/Seq.App.EmailPlus.Tests/EmailReactorTests.cs
@@ -129,7 +129,7 @@ namespace Seq.App.EmailPlus.Tests
         }
 
         [Fact]
-        public async Task SmtpOptionsCalculated()
+        public void SmtpOptionsCalculated()
         {
             var mail = new CollectingMailGateway();
             var reactor = new EmailApp(mail)

--- a/test/Seq.App.EmailPlus.Tests/Support/CollectingMailGateway.cs
+++ b/test/Seq.App.EmailPlus.Tests/Support/CollectingMailGateway.cs
@@ -10,9 +10,9 @@ namespace Seq.App.EmailPlus.Tests.Support
     {
         public List<SentMessage> Sent { get; } = new List<SentMessage>();
 
-        public async Task<MailResult> Send(SmtpClient client, SmtpOptions options, MimeMessage message)
+        public async Task<MailResult> Send(SmtpOptions options, MimeMessage message)
         {
-            await Task.Run(() => Sent.Add(new SentMessage(client, message)));
+            await Task.Run(() => Sent.Add(new SentMessage(message)));
             
             return new MailResult() {Success = true};
         }

--- a/test/Seq.App.EmailPlus.Tests/Support/CollectingMailGateway.cs
+++ b/test/Seq.App.EmailPlus.Tests/Support/CollectingMailGateway.cs
@@ -1,5 +1,8 @@
 ﻿using System.Collections.Generic;
-using System.Net.Mail;
+using System.Threading.Tasks;
+using MailKit.Net.Smtp;
+using MimeKit;
+
 
 namespace Seq.App.EmailPlus.Tests.Support
 {
@@ -7,9 +10,11 @@ namespace Seq.App.EmailPlus.Tests.Support
     {
         public List<SentMessage> Sent { get; } = new List<SentMessage>();
 
-        public void Send(SmtpClient client, MailMessage message)
+        public async Task<MailResult> Send(SmtpClient client, SmtpOptions options, MimeMessage message)
         {
-            Sent.Add(new SentMessage(client, message));
+            await Task.Run(() => Sent.Add(new SentMessage(client, message)));
+            
+            return new MailResult() {Success = true};
         }
     }
 }

--- a/test/Seq.App.EmailPlus.Tests/Support/CollectingMailGateway.cs
+++ b/test/Seq.App.EmailPlus.Tests/Support/CollectingMailGateway.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using MailKit.Net.Smtp;
 using MimeKit;
 
 
@@ -14,7 +13,14 @@ namespace Seq.App.EmailPlus.Tests.Support
         {
             await Task.Run(() => Sent.Add(new SentMessage(message)));
             
-            return new MailResult() {Success = true};
+            return new MailResult {Success = true};
+        }
+
+        public async Task<DnsMailResult> SendDns(DeliveryType deliveryType, SmtpOptions options, MimeMessage message)
+        {
+            await Task.Run(() => Sent.Add(new SentMessage(message)));
+            
+            return new DnsMailResult {Success = true};
         }
     }
 }

--- a/test/Seq.App.EmailPlus.Tests/Support/SentMessage.cs
+++ b/test/Seq.App.EmailPlus.Tests/Support/SentMessage.cs
@@ -6,12 +6,10 @@ namespace Seq.App.EmailPlus.Tests.Support
 {
     class SentMessage
     {
-        public SmtpClient Client { get; }
         public MimeMessage Message { get; }
 
-        public SentMessage(SmtpClient client, MimeMessage message)
+        public SentMessage(MimeMessage message)
         {
-            Client = client;
             Message = message;
         }
     }

--- a/test/Seq.App.EmailPlus.Tests/Support/SentMessage.cs
+++ b/test/Seq.App.EmailPlus.Tests/Support/SentMessage.cs
@@ -1,13 +1,15 @@
-﻿using System.Net.Mail;
+﻿
+using MailKit.Net.Smtp;
+using MimeKit;
 
 namespace Seq.App.EmailPlus.Tests.Support
 {
     class SentMessage
     {
         public SmtpClient Client { get; }
-        public MailMessage Message { get; }
+        public MimeMessage Message { get; }
 
-        public SentMessage(SmtpClient client, MailMessage message)
+        public SentMessage(SmtpClient client, MimeMessage message)
         {
             Client = client;
             Message = message;

--- a/test/Seq.App.EmailPlus.Tests/Support/SentMessage.cs
+++ b/test/Seq.App.EmailPlus.Tests/Support/SentMessage.cs
@@ -1,6 +1,4 @@
-﻿
-using MailKit.Net.Smtp;
-using MimeKit;
+﻿using MimeKit;
 
 namespace Seq.App.EmailPlus.Tests.Support
 {


### PR DESCRIPTION
Hey @nblumhardt,

This is the initial MailKit conversion that we discussed in #77 (I removed the SSL validation suppression option that I'd implemented). 

I noted that we can make use of async methods for MailKit so I've updated EmailPlus to use onasync, and provided opportunity to handle unsuccessful emails in future (eg. the fallback mailhost idea I mentioned) by implementing a MailResult class.

I used a couple of idea from FluentEmail wrt an 'Options' class (SmtpOptions) and left a couple of unused properties that would likely be used for some of the ideas from #77. 

I also ported over the $EventUri template that we added to Seq.App.Opsgenie as a nicety, and updated Handlebars.NET to the latest build (from v2.0.8 to v2.0.9).

As I was doing this I could envisage how we would go about implementing a number of the ideas from my list, but as agreed, I started with MailKit 😁

Cheers,

Matt