### PR TITLE
Clean up suppression entries as we go

### DIFF
--- a/seq-app-htmlemail.sln.DotSettings
+++ b/seq-app-htmlemail.sln.DotSettings
@@ -1,2 +1,3 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=seqid/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=seqid/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=suppressions/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Seq.App.EmailPlus/DirectMailGateway.cs
+++ b/src/Seq.App.EmailPlus/DirectMailGateway.cs
@@ -7,25 +7,17 @@ namespace Seq.App.EmailPlus
 {
     class DirectMailGateway : IMailGateway
     {
-        public async Task<MailResult> Send(SmtpOptions options, MimeMessage message)
+        public async Task SendAsync(SmtpOptions options, MimeMessage message)
         {
             if (message == null) throw new ArgumentNullException(nameof(message));
-            try
-            {
-                var client = new SmtpClient();
-                
-                await client.ConnectAsync(options.Server, options.Port, options.SocketOptions);
-                if (options.RequiresAuthentication)
-                    await client.AuthenticateAsync(options.User, options.Password);
-                await client.SendAsync(message);
-                await client.DisconnectAsync(true);
 
-                return new MailResult {Success = true};
-            }
-            catch (Exception ex)
-            {
-                return new MailResult {Success = false, Errors = ex};
-            }
+            var client = new SmtpClient();
+                
+            await client.ConnectAsync(options.Server, options.Port, options.SocketOptions);
+            if (options.RequiresAuthentication)
+                await client.AuthenticateAsync(options.Username, options.Password);
+            await client.SendAsync(message);
+            await client.DisconnectAsync(true);
         }
     }
 }

--- a/src/Seq.App.EmailPlus/IClock.cs
+++ b/src/Seq.App.EmailPlus/IClock.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Seq.App.EmailPlus
+{
+    interface IClock
+    {
+        DateTime UtcNow { get; }
+    }
+}

--- a/src/Seq.App.EmailPlus/IMailGateway.cs
+++ b/src/Seq.App.EmailPlus/IMailGateway.cs
@@ -1,13 +1,10 @@
-﻿
-
-using System.Threading.Tasks;
-using MailKit.Net.Smtp;
+﻿using System.Threading.Tasks;
 using MimeKit;
 
 namespace Seq.App.EmailPlus
 {
     interface IMailGateway
     {
-        Task<MailResult> Send(SmtpOptions options, MimeMessage message);
+        Task SendAsync(SmtpOptions options, MimeMessage message);
     }
 }

--- a/src/Seq.App.EmailPlus/SmtpOptions.cs
+++ b/src/Seq.App.EmailPlus/SmtpOptions.cs
@@ -9,7 +9,7 @@ namespace Seq.App.EmailPlus
     {
         public string Server { get; set; } = string.Empty;
         public int Port { get; set; } = 25;
-        public string User { get; set; } = string.Empty;
+        public string Username { get; set; } = string.Empty;
         public string Password { get; set; } = string.Empty;
         public bool RequiresAuthentication { get; set; }
         public SecureSocketOptions SocketOptions { get; set; }

--- a/src/Seq.App.EmailPlus/SystemClock.cs
+++ b/src/Seq.App.EmailPlus/SystemClock.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Seq.App.EmailPlus
+{
+    class SystemClock : IClock
+    {
+        public DateTime UtcNow => DateTime.UtcNow;
+    }
+}

--- a/test/Seq.App.EmailPlus.Tests/EmailAppTests.cs
+++ b/test/Seq.App.EmailPlus.Tests/EmailAppTests.cs
@@ -1,10 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-<<<<<<< HEAD:test/Seq.App.EmailPlus.Tests/EmailReactorTests.cs
-using System.Linq;
 using System.Threading.Tasks;
-=======
->>>>>>> 475ab11 (Fixes #75):test/Seq.App.EmailPlus.Tests/EmailAppTests.cs
 using Seq.App.EmailPlus.Tests.Support;
 using Seq.Apps;
 using Seq.Apps.LogEvents;
@@ -127,20 +123,15 @@ namespace Seq.App.EmailPlus.Tests
 
             app.Attach(new TestAppHost());
 
-<<<<<<< HEAD:test/Seq.App.EmailPlus.Tests/EmailReactorTests.cs
-            var data = Some.LogEvent(new Dictionary<string, object> { { "Name", "test" } });
-            await reactor.OnAsync(data);
-=======
             var data = Some.LogEvent(includedProperties: new Dictionary<string, object> { { "Name", "test" } });
-            app.On(data);
->>>>>>> 475ab11 (Fixes #75):test/Seq.App.EmailPlus.Tests/EmailAppTests.cs
+            await app.OnAsync(data);
 
             var sent = Assert.Single(mail.Sent);
             Assert.Equal("test@example.com", sent.Message.To.ToString());
         }
 
         [Fact]
-        public void EventsAreSuppressedWithinWindow()
+        public async Task EventsAreSuppressedWithinWindow()
         {
             var mail = new CollectingMailGateway();
             var clock = new TestClock();
@@ -154,23 +145,23 @@ namespace Seq.App.EmailPlus.Tests
 
             app.Attach(new TestAppHost());
 
-            app.On(Some.LogEvent(eventType: 99));
+            await app.OnAsync(Some.LogEvent(eventType: 99));
             clock.Advance(TimeSpan.FromMinutes(1));
-            app.On(Some.LogEvent(eventType: 99));
-            app.On(Some.LogEvent(eventType: 99));
+            await app.OnAsync(Some.LogEvent(eventType: 99));
+            await app.OnAsync(Some.LogEvent(eventType: 99));
 
             Assert.Single(mail.Sent);
             mail.Sent.Clear();
 
             clock.Advance(TimeSpan.FromHours(1));
 
-            app.On(Some.LogEvent(eventType: 99));
+            await app.OnAsync(Some.LogEvent(eventType: 99));
 
             Assert.Single(mail.Sent);
         }
 
         [Fact]
-        public void EventsAreSuppressedByType()
+        public async Task EventsAreSuppressedByType()
         {
             var mail = new CollectingMailGateway();
             var app = new EmailApp(mail, new SystemClock())
@@ -183,9 +174,9 @@ namespace Seq.App.EmailPlus.Tests
 
             app.Attach(new TestAppHost());
 
-            app.On(Some.LogEvent(eventType: 1));
-            app.On(Some.LogEvent(eventType: 2));
-            app.On(Some.LogEvent(eventType: 1));
+            await app.OnAsync(Some.LogEvent(eventType: 1));
+            await app.OnAsync(Some.LogEvent(eventType: 2));
+            await app.OnAsync(Some.LogEvent(eventType: 1));
 
             Assert.Equal(2, mail.Sent.Count);
         }

--- a/test/Seq.App.EmailPlus.Tests/Support/CollectingMailGateway.cs
+++ b/test/Seq.App.EmailPlus.Tests/Support/CollectingMailGateway.cs
@@ -3,18 +3,16 @@ using System.Threading.Tasks;
 using MailKit.Net.Smtp;
 using MimeKit;
 
-
 namespace Seq.App.EmailPlus.Tests.Support
 {
     class CollectingMailGateway : IMailGateway
     {
         public List<SentMessage> Sent { get; } = new List<SentMessage>();
 
-        public async Task<MailResult> Send(SmtpOptions options, MimeMessage message)
+        public Task SendAsync(SmtpOptions options, MimeMessage message)
         {
-            await Task.Run(() => Sent.Add(new SentMessage(message)));
-            
-            return new MailResult() {Success = true};
+            Sent.Add(new SentMessage(message));
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/Seq.App.EmailPlus.Tests/Support/Some.cs
+++ b/test/Seq.App.EmailPlus.Tests/Support/Some.cs
@@ -24,7 +24,7 @@ namespace Seq.App.EmailPlus.Tests.Support
             return Uint();
         }
 
-        public static Event<LogEventData> LogEvent(IDictionary<string, object> includedProperties = null)
+        public static Event<LogEventData> LogEvent(uint? eventType = null, IDictionary<string, object> includedProperties = null)
         {
             var id = EventId();
             var timestamp = UtcTimestamp();
@@ -42,7 +42,7 @@ namespace Seq.App.EmailPlus.Tests.Support
                 }
             }
 
-            return new Event<LogEventData>(id, EventType(), timestamp, new LogEventData
+            return new Event<LogEventData>(id, eventType ?? EventType(), timestamp, new LogEventData
             {
                 Exception = null,
                 Id = id,

--- a/test/Seq.App.EmailPlus.Tests/Support/TestClock.cs
+++ b/test/Seq.App.EmailPlus.Tests/Support/TestClock.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Seq.App.EmailPlus.Tests.Support
+{
+    class TestClock : IClock
+    {
+        public DateTime UtcNow { get; set; }
+
+        public DateTime Advance(TimeSpan duration)
+        {
+            UtcNow = UtcNow.Add(duration);
+            return UtcNow;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #75

Apps are single-threaded, so this turned out to be somewhat easier than expected.

We'll only clean up the dictionary as we add new items, so we'll avoid checking the suppression list when we receive a (probably chatty) event of suppressed type. This will mean entries may hang around longer than expected, but we're out of leak territory.