### PR TITLE
Delivery enhancements

### DIFF
--- a/src/Seq.App.EmailPlus/DeliveryType.cs
+++ b/src/Seq.App.EmailPlus/DeliveryType.cs
@@ -1,0 +1,12 @@
+﻿namespace Seq.App.EmailPlus
+{
+    public enum DeliveryType
+    {
+        MailHost,
+        MailFallback,
+        Dns,
+        DnsFallback,
+        HostDnsFallback,
+        None = -1
+    }
+}

--- a/src/Seq.App.EmailPlus/DirectMailGateway.cs
+++ b/src/Seq.App.EmailPlus/DirectMailGateway.cs
@@ -57,10 +57,11 @@ namespace Seq.App.EmailPlus
                     {
                         lastServer = server;
                         mailResult = await TryDeliver(server, options, message, type);
+                        var lastError = dnsResult.LastError;
                         dnsResult = new DnsMailResult()
                         {
                             LastServer = server,
-                            LastError = mailResult.Errors ?? mailResult.Errors,
+                            LastError = mailResult.Errors ?? lastError,
                             Type = type,
                             Success = mailResult.Success
                         };

--- a/src/Seq.App.EmailPlus/DirectMailGateway.cs
+++ b/src/Seq.App.EmailPlus/DirectMailGateway.cs
@@ -1,5 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
+using DnsClient;
+using DnsClient.Protocol;
 using MailKit.Net.Smtp;
 using MimeKit;
 
@@ -7,25 +11,125 @@ namespace Seq.App.EmailPlus
 {
     class DirectMailGateway : IMailGateway
     {
+        readonly SmtpClient _client = new SmtpClient();
+
         public async Task<MailResult> Send(SmtpOptions options, MimeMessage message)
         {
             if (message == null) throw new ArgumentNullException(nameof(message));
+            var mailResult = new MailResult();
+            var type = DeliveryType.MailHost;
+            foreach (var server in options.ServerList)
+            {
+                mailResult = await TryDeliver(server, options, message, type);
+                if (!mailResult.Success)
+                    type = DeliveryType.MailFallback;
+                else
+                    break;
+            }
+
+            return mailResult;
+        }
+
+        public async Task<DnsMailResult> SendDns(DeliveryType deliveryType, SmtpOptions options, MimeMessage message)
+        {
+            var dnsResult = new DnsMailResult {Success = true};
+            var resultList = new List<MailResult>();
+            var lastServer = string.Empty;
+            if (message == null) throw new ArgumentNullException(nameof(message));
+            var type = deliveryType;
+
             try
             {
-                var client = new SmtpClient();
-                
-                await client.ConnectAsync(options.Server, options.Port, options.SocketOptions);
-                if (options.RequiresAuthentication)
-                    await client.AuthenticateAsync(options.User, options.Password);
-                await client.SendAsync(message);
-                await client.DisconnectAsync(true);
+                var domains = GetDomains(message);
 
-                return new MailResult {Success = true};
+                var dnsClient = new LookupClient();
+                foreach (var domain in domains)
+                {
+                    type = deliveryType;
+                    lastServer = domain;
+                    var mx = await dnsClient.QueryAsync(domain, QueryType.MX);
+                    var mxServers =
+                        (from mxServer in mx.Answers
+                            where !string.IsNullOrEmpty(((MxRecord) mxServer).Exchange)
+                            select ((MxRecord) mxServer).Exchange).Select(dummy => (string) dummy).ToList();
+                    var mailResult = new MailResult();
+                    foreach (var server in mxServers)
+                    {
+                        lastServer = server;
+                        dnsResult.LastServer = server;
+                        dnsResult.Type = type;
+                        mailResult = await TryDeliver(server, options, message, type);
+                        resultList.Add(mailResult);
+
+                        if (mailResult.Success)
+                            break;
+                        type = DeliveryType.DnsFallback;
+                    }
+
+                    if (mailResult.Success) continue;
+                    dnsResult.LastServer = lastServer;
+                    dnsResult.Success = false;
+                    break;
+                }
             }
             catch (Exception ex)
             {
-                return new MailResult {Success = false, Errors = ex};
+                dnsResult.Type = type;
+                dnsResult.LastServer = lastServer;
+                dnsResult.Success = false;
+                dnsResult.LastError = ex;
+            }
+
+            dnsResult.Results = resultList;
+            return dnsResult;
+        }
+
+
+        private static IEnumerable<string> GetDomains(MimeMessage message)
+        {
+            var domains = new List<string>();
+            foreach (var to in message.To)
+            {
+                var toDomain = to.ToString().Split('@')[1];
+                if (string.IsNullOrEmpty(toDomain)) continue;
+                foreach (var domain in domains.Where(domain =>
+                    !toDomain.Equals(domain, StringComparison.OrdinalIgnoreCase)))
+                {
+                    domains.Add(toDomain);
+                }
+            }
+
+            return domains;
+        }
+
+        private async Task<MailResult> TryDeliver(string server, SmtpOptions options, MimeMessage message,
+            DeliveryType deliveryType)
+        {
+            if (string.IsNullOrEmpty(server))
+                return new MailResult {Success = false, LastServer = server, Type = deliveryType};
+            try
+            {
+                if (!string.IsNullOrEmpty(server))
+                {
+                    await _client.ConnectAsync(server, options.Port, options.SocketOptions);
+                    if (options.RequiresAuthentication)
+                        await _client.AuthenticateAsync(options.User, options.Password);
+                }
+                else
+                {
+                    var dnsClient = new LookupClient();
+                }
+
+                await _client.SendAsync(message);
+                await _client.DisconnectAsync(true);
+
+                return new MailResult {Success = true, LastServer = server, Type = deliveryType};
+            }
+            catch (Exception ex)
+            {
+                return new MailResult {Success = false, Errors = ex, LastServer = server, Type = deliveryType};
             }
         }
+
     }
 }

--- a/src/Seq.App.EmailPlus/DirectMailGateway.cs
+++ b/src/Seq.App.EmailPlus/DirectMailGateway.cs
@@ -109,19 +109,14 @@ namespace Seq.App.EmailPlus
                 return new MailResult {Success = false, LastServer = server, Type = deliveryType};
             try
             {
-                if (!string.IsNullOrEmpty(server))
-                {
-                    await _client.ConnectAsync(server, options.Port, options.SocketOptions);
-                    if (options.RequiresAuthentication)
-                        await _client.AuthenticateAsync(options.User, options.Password);
-                }
-                else
-                {
-                    var dnsClient = new LookupClient();
-                }
+                await _client.ConnectAsync(server, options.Port, options.SocketOptions);
+                if (options.RequiresAuthentication)
+                    await _client.AuthenticateAsync(options.User, options.Password);
+
 
                 await _client.SendAsync(message);
                 await _client.DisconnectAsync(true);
+
 
                 return new MailResult {Success = true, LastServer = server, Type = deliveryType};
             }

--- a/src/Seq.App.EmailPlus/DnsMailResult.cs
+++ b/src/Seq.App.EmailPlus/DnsMailResult.cs
@@ -9,6 +9,7 @@ namespace Seq.App.EmailPlus
         public DeliveryType Type { get; set; }
         public string LastServer { get; set; }
         public Exception LastError { get; set; }
-        public List<MailResult> Results { get; set; }
+        public List<Exception> Errors { get; set; } = new List<Exception>();
+        public List<MailResult> Results { get; set; } = new List<MailResult>();
     }
 }

--- a/src/Seq.App.EmailPlus/DnsMailResult.cs
+++ b/src/Seq.App.EmailPlus/DnsMailResult.cs
@@ -1,12 +1,14 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Seq.App.EmailPlus
 {
-    public class MailResult
+    public class DnsMailResult
     {
         public bool Success { get; set; }
         public DeliveryType Type { get; set; }
         public string LastServer { get; set; }
-        public Exception Errors { get; set; }
+        public Exception LastError { get; set; }
+        public List<MailResult> Results { get; set; }
     }
 }

--- a/src/Seq.App.EmailPlus/EmailApp.cs
+++ b/src/Seq.App.EmailPlus/EmailApp.cs
@@ -3,10 +3,8 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
-using System.Net;
 using System.Threading.Tasks;
 using HandlebarsDotNet;
-using MailKit.Net.Smtp;
 using MailKit.Security;
 using MimeKit;
 using Seq.Apps;
@@ -25,7 +23,7 @@ namespace Seq.App.EmailPlus
         readonly IMailGateway _mailGateway = new DirectMailGateway();
         readonly ConcurrentDictionary<uint, DateTime> _lastSeen = new ConcurrentDictionary<uint, DateTime>();
         readonly Lazy<Template> _bodyTemplate, _subjectTemplate, _toAddressesTemplate;
-        readonly SmtpOptions _options;
+        public readonly Lazy<SmtpOptions> Options;
 
         const string DefaultSubjectTemplate = @"[{{$Level}}] {{{$Message}}} (via Seq)";
         const int MaxSubjectLength = 130;
@@ -43,16 +41,18 @@ namespace Seq.App.EmailPlus
 
         public EmailApp()
         {
-            _options = _options = new SmtpOptions()
+            Options = new Lazy<SmtpOptions>(() => new SmtpOptions
             {
-                Server = Host, Port = Port ?? 25,
+                Server = Host,
+                DnsDelivery = DeliverUsingDns != null && (bool) DeliverUsingDns,
+                Port = Port ?? 25,
                 SocketOptions = EnableSsl != null && (bool) EnableSsl
                     ? SecureSocketOptions.SslOnConnect
                     : SecureSocketOptions.StartTlsWhenAvailable,
                 User = Username, Password = Password,
                 RequiresAuthentication = !string.IsNullOrEmpty(Username) && !string.IsNullOrEmpty(Password)
-            };
-            
+            });
+
             _subjectTemplate = new Lazy<Template>(() =>
             {
                 var subjectTemplate = SubjectTemplate;
@@ -95,8 +95,13 @@ namespace Seq.App.EmailPlus
         public string SubjectTemplate { get; set; }
 
         [SeqAppSetting(
-            HelpText = "The name of the SMTP server machine.")]
+            HelpText = "The name of the SMTP server machine. Optionally specify fallback hosts as comma-delimited string.",
+            IsOptional = true)]
         public new string Host { get; set; }
+
+        [SeqAppSetting(
+            HelpText = "Deliver directly using DNS. If Host is configured, this will be used as a fallback delivery mechanism.")]
+        public bool? DeliverUsingDns { get; set; }
 
         [SeqAppSetting(
             IsOptional = true,
@@ -148,20 +153,68 @@ namespace Seq.App.EmailPlus
                 _lastSeen[evt.EventType] = DateTime.UtcNow;
             }
 
-            var to = FormatTemplate(_toAddressesTemplate.Value, evt, base.Host);
+            var to = FormatTemplate(_toAddressesTemplate.Value, evt, base.Host)
+                .Split(new[] {','}, StringSplitOptions.RemoveEmptyEntries)
+                .Select(t => t.Trim()).ToList();
             var body = FormatTemplate(_bodyTemplate.Value, evt, base.Host);
             var subject = FormatTemplate(_subjectTemplate.Value, evt, base.Host).Trim().Replace("\r", "")
                 .Replace("\n", "");
             if (subject.Length > MaxSubjectLength)
                 subject = subject.Substring(0, MaxSubjectLength);
 
-            var result = await _mailGateway.Send(_options, new MimeMessage(new List<InternetAddress> {MailboxAddress.Parse(From)},
-                new List<InternetAddress> {MailboxAddress.Parse(to)}, subject,
-                (new BodyBuilder() {HtmlBody = body}).ToMessageBody()));
+            var toList = to.Select(MailboxAddress.Parse).ToList();
 
-            if (!result.Success)
-                throw result.Errors;
+            var sent = false;
+            var type = DeliveryType.None;
+            var message = new MimeMessage(
+                new List<InternetAddress> {InternetAddress.Parse(From)},
+                toList, subject, (new BodyBuilder {HtmlBody = body}).ToMessageBody());
 
+            Exception lastError = null;
+            if (Options.Value.Server.Any())
+            {
+                type = DeliveryType.MailHost;
+                var result = await _mailGateway.Send(Options.Value, message);
+
+                sent = result.Success;
+                if (!result.Success)
+                {
+                    lastError = result.Errors;
+                    Log.ForContext("From", From).ForContext("To", to).ForContext("Subject", subject)
+                        .ForContext("Success", sent).ForContext("Body", body)
+                        .ForContext(nameof(result.LastServer), result.LastServer)
+                        .ForContext(nameof(result.Type), result.Type).Error(result.Errors, "Error sending mail: ",
+                            result.Errors.Message);
+                }
+            }
+
+            if (!sent && Options.Value.DnsDelivery)
+            {
+                type = type == DeliveryType.None ? DeliveryType.Dns : DeliveryType.HostDnsFallback;
+                var result = await _mailGateway.SendDns(type, Options.Value, message);
+                sent = result.Success;
+
+                if (!result.Success)
+                {
+                    lastError = result.LastError;
+                    Log.ForContext("From", From).ForContext("To", to).ForContext("Subject", subject)
+                        .ForContext("Success", sent).ForContext("Body", body)
+                        .ForContext(nameof(result.Results), result.Results, true)
+                        .ForContext(nameof(result.LastServer), result.LastServer).Error(result.LastError,
+                            "Error sending mail via DNS: ", result.LastError.Message);
+                }
+            }
+
+            switch (sent)
+            {
+                case false when lastError != null:
+                    throw lastError;
+                case true:
+                    Log.ForContext("From", From).ForContext("To", to).ForContext("Subject", subject)
+                        .ForContext("Success", true).ForContext("Body", body)
+                        .Information("Mail Sent, From {From}, To: {To}, Subject: {Subject}");
+                    break;
+            }
         }
 
         public static string FormatTemplate(Template template, Event<LogEventData> evt, Host host)

--- a/src/Seq.App.EmailPlus/HandlebarsHelpers.cs
+++ b/src/Seq.App.EmailPlus/HandlebarsHelpers.cs
@@ -2,7 +2,6 @@
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 
 namespace Seq.App.EmailPlus

--- a/src/Seq.App.EmailPlus/IMailGateway.cs
+++ b/src/Seq.App.EmailPlus/IMailGateway.cs
@@ -1,5 +1,6 @@
 ﻿
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using MimeKit;
 

--- a/src/Seq.App.EmailPlus/IMailGateway.cs
+++ b/src/Seq.App.EmailPlus/IMailGateway.cs
@@ -1,7 +1,6 @@
 ﻿
 
 using System.Threading.Tasks;
-using MailKit.Net.Smtp;
 using MimeKit;
 
 namespace Seq.App.EmailPlus
@@ -9,5 +8,6 @@ namespace Seq.App.EmailPlus
     interface IMailGateway
     {
         Task<MailResult> Send(SmtpOptions options, MimeMessage message);
+        Task<DnsMailResult> SendDns(DeliveryType deliveryType, SmtpOptions options, MimeMessage message);
     }
 }

--- a/src/Seq.App.EmailPlus/MailResult.cs
+++ b/src/Seq.App.EmailPlus/MailResult.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Seq.App.EmailPlus
 {
@@ -7,6 +8,7 @@ namespace Seq.App.EmailPlus
         public bool Success { get; set; }
         public DeliveryType Type { get; set; }
         public string LastServer { get; set; }
-        public Exception Errors { get; set; }
+        public Exception LastError { get; set; }
+        public List<Exception> Errors { get; set; } = new List<Exception>();
     }
 }

--- a/src/Seq.App.EmailPlus/Seq.App.EmailPlus.csproj
+++ b/src/Seq.App.EmailPlus/Seq.App.EmailPlus.csproj
@@ -17,6 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="DnsClient" Version="1.5.0" />
     <PackageReference Include="MailKit" Version="2.14.0" />
     <PackageReference Include="Seq.Apps" Version="5.1.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />

--- a/src/Seq.App.EmailPlus/SmtpOptions.cs
+++ b/src/Seq.App.EmailPlus/SmtpOptions.cs
@@ -1,17 +1,31 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Linq;
 using MailKit.Security;
 
 namespace Seq.App.EmailPlus
 {
-    class SmtpOptions
+    public class SmtpOptions
     {
-        public string Server { get; set; } = string.Empty;
+        public string Server { get; set; }
+        public bool DnsDelivery { get; set; }
         public int Port { get; set; } = 25;
         public string User { get; set; } = string.Empty;
         public string Password { get; set; } = string.Empty;
         public bool RequiresAuthentication { get; set; }
         public SecureSocketOptions SocketOptions { get; set; }
+
+        public IEnumerable<string> ServerList
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(Server))
+                    return Server.Split(new[] {','}, StringSplitOptions.RemoveEmptyEntries)
+                        .Select(t => t.Trim()).ToList();
+                return new List<string>();
+            }
+        }
     }
+
+    
 }

--- a/test/Seq.App.EmailPlus.Tests/EmailReactorTests.cs
+++ b/test/Seq.App.EmailPlus.Tests/EmailReactorTests.cs
@@ -2,19 +2,28 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using MimeKit;
 using Seq.App.EmailPlus.Tests.Support;
 using Seq.Apps;
 using Seq.Apps.LogEvents;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Seq.App.EmailPlus.Tests
 {
     public class EmailReactorTests
     {
+        private readonly ITestOutputHelper _testOutputHelper;
+
         static EmailReactorTests()
         {
             // Ensure the handlebars helpers are registered.
             GC.KeepAlive(new EmailApp());
+        }
+
+        public EmailReactorTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
         }
 
         [Fact]
@@ -142,5 +151,56 @@ namespace Seq.App.EmailPlus.Tests
             reactor.Attach(new TestAppHost());
             Assert.True(reactor.Options.Value.ServerList.Count() == 2);
         }
+
+        [Fact]
+        public void ParseDomainTest()
+        {
+            var mail = new DirectMailGateway();
+            var domains = DirectMailGateway.GetDomains(new MimeMessage(
+                new List<InternetAddress> {InternetAddress.Parse("test@example.com")},
+                new List<InternetAddress> {InternetAddress.Parse("test2@example.com"), InternetAddress.Parse("test3@example.com"), InternetAddress.Parse("test@example2.com")}, "Test",
+                (new BodyBuilder {HtmlBody = "test"}).ToMessageBody()));
+            Assert.True(domains.Count() == 2);
+        }
+
+        //[Fact]
+        //public async Task MailHostDeliveryTest()
+        //{
+        //    var reactor = new EmailApp()
+        //    {
+        //        Host = "fqdn",
+        //        EnableSsl = false,
+        //        From = "test@example.com",
+        //        To = "testdest@example.com",
+        //        BodyTemplate = "Test Body",
+        //        SubjectTemplate = "Test Email"
+        //    };
+
+        //    reactor.Attach(new TestAppHost());
+        //    var data = Some.LogEvent(new Dictionary<string, object> { { "Name", "test" } });
+        //    await reactor.OnAsync(data);
+
+        //}
+        
+        //[Fact]
+        //public async Task SmtpDnsDeliveryTest()
+        //{
+        //    var mail = new DirectMailGateway();
+        //    var reactor = new EmailApp(mail)
+        //    {
+        //        DeliverUsingDns = true,
+        //        EnableSsl = false,
+        //        From = "test@example.com",
+        //        To = "testdest@example.com",
+        //        BodyTemplate = "Test Body",
+        //        SubjectTemplate = "Test Email"
+        //    };
+
+        //    reactor.Attach(new TestAppHost());
+        //    var x = await mail.SendDns(DeliveryType.Dns, reactor.Options.Value, new MimeMessage(
+        //        new List<InternetAddress> {InternetAddress.Parse(reactor.From)},
+        //        new List<InternetAddress> {InternetAddress.Parse(reactor.To)}, reactor.SubjectTemplate, (new BodyBuilder {HtmlBody = reactor.BodyTemplate}).ToMessageBody()));
+        //    _testOutputHelper.WriteLine("{0}: {1}", x.Success, x.LastError);
+        //}
     }
 }

--- a/test/Seq.App.EmailPlus.Tests/EmailReactorTests.cs
+++ b/test/Seq.App.EmailPlus.Tests/EmailReactorTests.cs
@@ -122,12 +122,25 @@ namespace Seq.App.EmailPlus.Tests
             };
 
             reactor.Attach(new TestAppHost());
-
             var data = Some.LogEvent(new Dictionary<string, object> { { "Name", "test" } });
             await reactor.OnAsync(data);
-
             var sent = mail.Sent.Single();
             Assert.Equal("test@example.com", sent.Message.To.ToString());
+        }
+
+        [Fact]
+        public async Task SmtpOptionsCalculated()
+        {
+            var mail = new CollectingMailGateway();
+            var reactor = new EmailApp(mail)
+            {
+                From = "from@example.com",
+                To = "{{Name}}@example.com",
+                Host = "example.com,example2.com"
+            };
+
+            reactor.Attach(new TestAppHost());
+            Assert.True(reactor.Options.Value.ServerList.Count() == 2);
         }
     }
 }

--- a/test/Seq.App.EmailPlus.Tests/EmailReactorTests.cs
+++ b/test/Seq.App.EmailPlus.Tests/EmailReactorTests.cs
@@ -129,7 +129,7 @@ namespace Seq.App.EmailPlus.Tests
         }
 
         [Fact]
-        public async Task SmtpOptionsCalculated()
+        public void SmtpOptionsCalculated()
         {
             var mail = new CollectingMailGateway();
             var reactor = new EmailApp(mail)

--- a/test/Seq.App.EmailPlus.Tests/Support/CollectingMailGateway.cs
+++ b/test/Seq.App.EmailPlus.Tests/Support/CollectingMailGateway.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using MailKit.Net.Smtp;
 using MimeKit;
 
 
@@ -14,7 +13,14 @@ namespace Seq.App.EmailPlus.Tests.Support
         {
             await Task.Run(() => Sent.Add(new SentMessage(message)));
             
-            return new MailResult() {Success = true};
+            return new MailResult {Success = true};
+        }
+
+        public async Task<DnsMailResult> SendDns(DeliveryType deliveryType, SmtpOptions options, MimeMessage message)
+        {
+            await Task.Run(() => Sent.Add(new SentMessage(message)));
+            
+            return new DnsMailResult {Success = true};
         }
     }
 }

--- a/test/Seq.App.EmailPlus.Tests/Support/SentMessage.cs
+++ b/test/Seq.App.EmailPlus.Tests/Support/SentMessage.cs
@@ -1,6 +1,4 @@
-﻿
-using MailKit.Net.Smtp;
-using MimeKit;
+﻿using MimeKit;
 
 namespace Seq.App.EmailPlus.Tests.Support
 {


### PR DESCRIPTION
@nblumhardt This is the next feature set for whenever you get around to review - mail host fallback (comma-delimited list of mail hosts) and using DNS to deliver emails directly.

It also corrects deficiencies from #79 .. I'm not sure if the switch to logging mail send results fully addresses your comment on losing the original stack trace but I think it should go some way. I was concerned to be able to preserve exceptions from each mail host / DNS delivery attempt, with the last error forming the basis for an exception log. I think it's handled appropriately but always appreciate your insight. 

I left the test cases in place for actually sending emails that I used to ensure all was working as expected, but commented out. This was strictly a convenience and I'm fully anticipating your comment that they need to be removed 😂

Cheers,

Matt