### PR TITLE
Fix Newtonsoft.Json dependency version, initialization bug

### DIFF
--- a/src/Seq.App.EmailPlus/DirectMailGateway.cs
+++ b/src/Seq.App.EmailPlus/DirectMailGateway.cs
@@ -13,7 +13,7 @@ namespace Seq.App.EmailPlus
 
             var client = new SmtpClient();
                 
-            await client.ConnectAsync(options.Server, options.Port, options.SocketOptions);
+            await client.ConnectAsync(options.Host, options.Port, options.SocketOptions);
             if (options.RequiresAuthentication)
                 await client.AuthenticateAsync(options.Username, options.Password);
             await client.SendAsync(message);

--- a/src/Seq.App.EmailPlus/EmailApp.cs
+++ b/src/Seq.App.EmailPlus/EmailApp.cs
@@ -38,17 +38,14 @@ namespace Seq.App.EmailPlus
             _mailGateway = mailGateway ?? throw new ArgumentNullException(nameof(mailGateway));
             _clock = clock ?? throw new ArgumentNullException(nameof(clock));
 
-            _options = _options = new Lazy<SmtpOptions>(() => new SmtpOptions
-            {
-                Host = Host,
-                Port = Port ?? 25,
-                SocketOptions = EnableSsl ?? false
+            _options = _options = new Lazy<SmtpOptions>(() => new SmtpOptions(
+                Host,
+                Port ?? 25, 
+                EnableSsl ?? false
                     ? SecureSocketOptions.SslOnConnect
-                    : SecureSocketOptions.StartTlsWhenAvailable,
-                Username = Username,
-                Password = Password,
-                RequiresAuthentication = !string.IsNullOrEmpty(Username) && !string.IsNullOrEmpty(Password)
-            });
+                    : SecureSocketOptions.StartTlsWhenAvailable, 
+                Username,
+                Password));
             
             _subjectTemplate = new Lazy<Template>(() =>
             {

--- a/src/Seq.App.EmailPlus/EmailApp.cs
+++ b/src/Seq.App.EmailPlus/EmailApp.cs
@@ -23,7 +23,7 @@ namespace Seq.App.EmailPlus
         readonly IClock _clock;
         readonly Dictionary<uint, DateTime> _suppressions = new Dictionary<uint, DateTime>();
         readonly Lazy<Template> _bodyTemplate, _subjectTemplate, _toAddressesTemplate;
-        readonly SmtpOptions _options;
+        readonly Lazy<SmtpOptions> _options;
 
         const string DefaultSubjectTemplate = @"[{{$Level}}] {{{$Message}}} (via Seq)";
         const int MaxSubjectLength = 130;
@@ -38,7 +38,7 @@ namespace Seq.App.EmailPlus
             _mailGateway = mailGateway ?? throw new ArgumentNullException(nameof(mailGateway));
             _clock = clock ?? throw new ArgumentNullException(nameof(clock));
 
-            _options = _options = new SmtpOptions
+            _options = _options = new Lazy<SmtpOptions>(() => new SmtpOptions
             {
                 Host = Host,
                 Port = Port ?? 25,
@@ -48,7 +48,7 @@ namespace Seq.App.EmailPlus
                 Username = Username,
                 Password = Password,
                 RequiresAuthentication = !string.IsNullOrEmpty(Username) && !string.IsNullOrEmpty(Password)
-            };
+            });
             
             _subjectTemplate = new Lazy<Template>(() =>
             {
@@ -148,7 +148,7 @@ namespace Seq.App.EmailPlus
                 subject = subject.Substring(0, MaxSubjectLength);
 
             await _mailGateway.SendAsync(
-                _options,
+                _options.Value,
                 new MimeMessage(
                     new List<InternetAddress> {MailboxAddress.Parse(From)},
                     new List<InternetAddress> {MailboxAddress.Parse(to)},

--- a/src/Seq.App.EmailPlus/EmailApp.cs
+++ b/src/Seq.App.EmailPlus/EmailApp.cs
@@ -38,10 +38,9 @@ namespace Seq.App.EmailPlus
             _mailGateway = mailGateway ?? throw new ArgumentNullException(nameof(mailGateway));
             _clock = clock ?? throw new ArgumentNullException(nameof(clock));
 
-            // ReSharper disable ExpressionIsAlwaysNull ConditionIsAlwaysTrueOrFalse
             _options = _options = new SmtpOptions
             {
-                Server = Host,
+                Host = Host,
                 Port = Port ?? 25,
                 SocketOptions = EnableSsl ?? false
                     ? SecureSocketOptions.SslOnConnect
@@ -50,7 +49,6 @@ namespace Seq.App.EmailPlus
                 Password = Password,
                 RequiresAuthentication = !string.IsNullOrEmpty(Username) && !string.IsNullOrEmpty(Password)
             };
-            // ReSharper restore ExpressionIsAlwaysNull ConditionIsAlwaysTrueOrFalse
             
             _subjectTemplate = new Lazy<Template>(() =>
             {

--- a/src/Seq.App.EmailPlus/Seq.App.EmailPlus.csproj
+++ b/src/Seq.App.EmailPlus/Seq.App.EmailPlus.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Seq.Apps" Version="5.1.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Handlebars.Net" Version="2.0.9" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Seq.App.EmailPlus/SmtpOptions.cs
+++ b/src/Seq.App.EmailPlus/SmtpOptions.cs
@@ -7,7 +7,7 @@ namespace Seq.App.EmailPlus
 {
     class SmtpOptions
     {
-        public string Server { get; set; } = string.Empty;
+        public string Host { get; set; } = string.Empty;
         public int Port { get; set; } = 25;
         public string Username { get; set; } = string.Empty;
         public string Password { get; set; } = string.Empty;

--- a/src/Seq.App.EmailPlus/SmtpOptions.cs
+++ b/src/Seq.App.EmailPlus/SmtpOptions.cs
@@ -1,17 +1,25 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using MailKit.Security;
 
 namespace Seq.App.EmailPlus
 {
     class SmtpOptions
     {
-        public string Host { get; set; } = string.Empty;
-        public int Port { get; set; } = 25;
-        public string Username { get; set; } = string.Empty;
-        public string Password { get; set; } = string.Empty;
-        public bool RequiresAuthentication { get; set; }
-        public SecureSocketOptions SocketOptions { get; set; }
+        public string Host { get; }
+        public int Port { get; }
+        public string Username { get; }
+        public string Password { get; }
+        public SecureSocketOptions SocketOptions { get; }
+
+        public bool RequiresAuthentication => !string.IsNullOrEmpty(Username) && !string.IsNullOrEmpty(Password);
+
+        public SmtpOptions(string host, int port, SecureSocketOptions socketOptions, string username = null, string password = null)
+        {
+            Host = host ?? throw new ArgumentNullException(nameof(host));
+            Port = port;
+            Username = username;
+            Password = password;
+            SocketOptions = socketOptions;
+        }
     }
 }


### PR DESCRIPTION
The current -dev package is broken:

 * Newtonsoft.Json 13.x isn't supplied by the `seqcli` host
 * `SmtpOptions _options` can't be initialized in the ctor, as the properties it relies on aren't yet initialized (ReSharper was right, here :-))