### PR TITLE
Adds option to fully skip mail server certificate validation.

### DIFF
--- a/src/Seq.App.EmailPlus/DirectMailGateway.cs
+++ b/src/Seq.App.EmailPlus/DirectMailGateway.cs
@@ -12,7 +12,10 @@ namespace Seq.App.EmailPlus
             if (message == null) throw new ArgumentNullException(nameof(message));
 
             var client = new SmtpClient();
-                
+
+            if (options.SkipServerCertificateValidation)
+                client.ServerCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true;
+
             await client.ConnectAsync(options.Host, options.Port, options.SocketOptions);
             if (options.RequiresAuthentication)
                 await client.AuthenticateAsync(options.Username, options.Password);

--- a/src/Seq.App.EmailPlus/EmailApp.cs
+++ b/src/Seq.App.EmailPlus/EmailApp.cs
@@ -80,6 +80,12 @@ namespace Seq.App.EmailPlus
 
         [SeqAppSetting(
             IsOptional = true,
+            DisplayName = "Skip Server Certificate Validation",
+            HelpText = "Check this box to skip Server Certificate validation")]
+        public bool? SkipServerCertificateValidation { get; set; }
+
+        [SeqAppSetting(
+            IsOptional = true,
             InputType = SettingInputType.LongText,
             DisplayName = "Body template",
             HelpText = "The template to use when generating the email body, using Handlebars syntax. Leave this blank to use " +
@@ -113,6 +119,7 @@ namespace Seq.App.EmailPlus
                 EnableSsl ?? false
                     ? RequireSslForPort(port)
                     : SecureSocketOptions.StartTlsWhenAvailable,
+                SkipServerCertificateValidation ?? false,
                 Username,
                 Password);
 

--- a/src/Seq.App.EmailPlus/SmtpOptions.cs
+++ b/src/Seq.App.EmailPlus/SmtpOptions.cs
@@ -10,16 +10,24 @@ namespace Seq.App.EmailPlus
         public string Username { get; }
         public string Password { get; }
         public SecureSocketOptions SocketOptions { get; }
+        public bool SkipServerCertificateValidation { get; }
 
         public bool RequiresAuthentication => !string.IsNullOrEmpty(Username) && !string.IsNullOrEmpty(Password);
 
-        public SmtpOptions(string host, int port, SecureSocketOptions socketOptions, string username = null, string password = null)
+        public SmtpOptions(
+            string host,
+            int port,
+            SecureSocketOptions socketOptions,
+            bool skipServerCertificateValidation,
+            string username = null,
+            string password = null)
         {
             Host = host ?? throw new ArgumentNullException(nameof(host));
             Port = port;
             Username = username;
             Password = password;
             SocketOptions = socketOptions;
+            SkipServerCertificateValidation = skipServerCertificateValidation;
         }
     }
 }


### PR DESCRIPTION
This feature is meant to fully skip the server certificate validation.
This is meant to be a workaround if you run seq on prem and the reverse proxy used by organisation is messing up with the mail server certificates.
Refs #89